### PR TITLE
Support output state based acceptance automata

### DIFF
--- a/hoa/stateacc.hoa
+++ b/hoa/stateacc.hoa
@@ -1,0 +1,19 @@
+HOA: v1
+States: 10
+Start: 0
+AP: 2 "p0" "p1"
+acc-name: Buchi
+Acceptance: 1 Inf(0)
+properties: trans-labels explicit-labels state-acc
+--BODY--
+State: 0
+[!0&!1] 1
+[ 0&!1] 1
+[ !0&1] 1
+[0 & 1] 0
+State: 1 {0}
+[!0&!1] 0
+[ 0&!1] 0
+[!0& 1] 1
+[ 0 &1] 1
+--END--

--- a/src/format.rs
+++ b/src/format.rs
@@ -55,7 +55,7 @@ impl AcceptanceSignature {
     /// Tries to get the singleton element of the acceptance signature, if it exists.
     /// Returns `None` if the acceptance signature is not a singleton.
     pub fn get_singleton(&self) -> Option<Option<Id>> {
-        if self.len() == 0 {
+        if self.is_empty() {
             Some(None)
         } else if self.len() == 1 {
             Some(Some(self[0]))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,6 +533,7 @@ mod tests {
     use crate::{
         body::{Edge, State},
         header::Header,
+        output::to_hoa,
         AcceptanceAtom, AcceptanceCondition, AcceptanceName, AcceptanceSignature, Body, HeaderItem,
         HoaAutomaton, Label, StateConjunction, ALPHABET, VARS,
     };
@@ -635,5 +636,13 @@ mod tests {
                 Body::from(vec![q0, q1, q2])
             ))
         )
+    }
+
+    #[test]
+    fn real_test_state_acc() {
+        let contents = include_str!("../hoa/stateacc.hoa");
+        let hoa_aut = HoaAutomaton::try_from(contents);
+        let result = to_hoa(&hoa_aut.unwrap());
+        assert!(result.contains("State: 1 {0}"));
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -63,7 +63,7 @@ pub fn acceptance_info() -> impl Parser<Token, AcceptanceInfo, Error = Simple<To
 pub fn label_expression() -> impl Parser<Token, AbstractLabelExpression, Error = Simple<Token>> {
     recursive(|label_expression| {
         let value = boolean()
-            .map(|b| AbstractLabelExpression::Boolean(b))
+            .map(AbstractLabelExpression::Boolean)
             .or(integer().map(|i| AbstractLabelExpression::Integer(i as u16)));
         // .or(alias_name().map(|aname| LabelExpression::Alias(AliasName(aname))));
 


### PR DESCRIPTION
For me state based acceptance  automata are easier to read.

So if `state-acc` is set in property, then I think we may try to output the automata in a state based format.